### PR TITLE
Make Azote FPC compatible.

### DIFF
--- a/clt/Azote.dpr
+++ b/clt/Azote.dpr
@@ -1,12 +1,14 @@
 program Azote;
 
+{$IFNDEF FPC}
 {$APPTYPE CONSOLE}
+{$ENDIF}
 
 {$R *.res}
 
 
 uses
-  System.SysUtils,
+  {$IFNDEF FPC}System.{$ENDIF}SysUtils,
   Azote.Disassembler.AArch64 in '..\source\disasm\arch\AArch64\Azote.Disassembler.AArch64.pas',
   Azote.Printer.AArch64 in '..\source\print\arch\AArch64\Azote.Printer.AArch64.pas';
 
@@ -52,7 +54,11 @@ type
 var
   I: Integer;
   Param: string;
+  {$IFDEF FPC}
+  OpCodes: TStringArray;
+  {$ELSE}
   OpCodes: TArray<string>;
+  {$ENDIF}
   S, E: string;
   OpCode: UInt32;
   Commands: TCommands;


### PR DESCRIPTION
Congratulation for this great project!
In commit some modifs to make Azote compilable with last FPC compiler.
It works perfectly on Rpi OS 32 and 64 bit.

Here the command line to compile _Azote.dpr_ with _fpc_:

`fpc -Mobjfpc -Sh Azote.dpr`

Many thanks to share that great disassembler.

Fre;D